### PR TITLE
remove http from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "cron": "^1.0.9",
     "express": "^4.13.3",
-    "http": "0.0.0",
     "johnny-five": "^0.9.11",
     "particle-io": "^0.10.1",
     "socket.io": "^1.3.7"


### PR DESCRIPTION
fixes #11 

def double check that this still works before merging. i think it should, but i'm not as familiar with how you are using `http`
