### PR TITLE
quick pass at the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # robokitty
-Is a DIY cat (or dog, or human) feeder controlled over the web (locally for now).
+Is a DIY cat (or dog, or human) feeder controlled over the web (though not over
+the public Internet for now).
 
-There are two different feeding methods: feed instantly with the press of a button, or set up a CRON job to feed at hourly intervals.
+There are two different feeding methods: instant feeding with the click of a button, or scheduled feedings (using a command scheduler like cron).
 
-The idea behind the project is over the past few years all of the feeders I've came across have had a level of complication that weren't very user-friendly to new coders, and I wanted to make something that is hopefully easy enough for everyone to use.
+The idea behind the project came about because over the past few years all of the feeders I've came across have had a level of complication that weren't very user-friendly to new coders, and I wanted to make something that is easy enough for everyone to use.
 
 Let's get started!
 
@@ -27,7 +28,7 @@ Let's get started!
 * Solder
 * Wire Strippers
 * Heat Shrink Tube
-* Method of attaching servo horn to feeder, I used Loctite plastics bonding system which ruled.
+* Method of attaching servo horn to feeder, I used [Loctite plastic bonder](http://www.loctiteproducts.com/p/epxy_plstc_s/overview/Loctite-Epoxy-Plastic-Bonder.htm) which ruled.
 
 ## How-To
 
@@ -35,17 +36,17 @@ Once you have all of your materials handy, you're ready to start.
 
 ### Setting up your Particle Photon
 
-A great guide can be found right on the Particle site [here](https://docs.particle.io/guide/getting-started/connect/photon/), but I will walk you through it! I'm going to assume you're doing this from scratch and don't have anything installed on your computer.
+A great guide can be found [right on the Particle site](https://docs.particle.io/guide/getting-started/connect/photon/), but I will walk you through it! I'm going to assume you're doing this from scratch and don't have anything installed on your computer.
 
 Make sure you've already set up an account and logged in on the Particle website before starting the tutorial.
 
-First thing you need to do is power up the photon, plug in the cable and connect it to your computer.
+First thing you need to do is power up the Photon, plug in the cable and connect it to your computer.
 
-Now you need to install Node, for sake of ease, go to the [Node site](https://nodejs.org/) and grab the latest version.
+Now you need to install Node, for sake of ease, go to the [Node.js site](https://nodejs.org/) and grab the latest version.
 
-Once you've gotten Node installed, the next step differs depending on if you're using a Mac OS or Windows.
+Once you've gotten Node installed, the next step differs depending on if you're using Mac OS or Windows.
 
-If you are on a Windows machine, please follow the steps called "Installing the Particle Driver" and "Opening the Command Prompt" which you can find [here](https://docs.particle.io/guide/getting-started/connect/photon/#installing-the-particle-driver).
+If you are on a Windows machine, please follow [the steps on the Particle site](https://docs.particle.io/guide/getting-started/connect/photon/#installing-the-particle-driver) called "Installing the Particle Driver" and "Opening the Command Prompt".
 
 If you are on a Mac, there are no additional steps to take before our next one.
 
@@ -54,9 +55,12 @@ It's time to install the Particle CLI (Command Line Interface)!
 ### Particle CLI
 
 Open up your CLI of choice, and type 
+
 ```
 npm install -g particle-cli
 ```
+
+This command may require sudo access.
 
 Once it is done downloading, type 
 
@@ -69,23 +73,23 @@ And answer the prompts with the login information you created earlier for the Pa
 
 ### Claiming a Photon
 
-The Particle site has a thorough guide to claiming and setting up a photon [here](https://docs.particle.io/guide/getting-started/connect/photon/#connecting-your-device).
+The Particle site has a [thorough guide to claiming and setting up a photon](https://docs.particle.io/guide/getting-started/connect/photon/#connecting-your-device).
 
 
 ### Firmware
 Now we need to flash the Photon with new Firmware. We're going to be using [VoodooSpark](https://github.com/voodootikigod/voodoospark).
 
-If you have already claimed your photon correctly, you're going to need your photon id. Type the following, and keep track of what the number is because you'll need it shortly.
+If you have already claimed your photon correctly, you're going to need your Photon ID. Type the following, and keep track of what the number is because you'll need it shortly.
 
 ```
 particle serial identify
 ```
 
-The first thing you need after this is grab the latest version of the firmware from [here](https://github.com/voodootikigod/voodoospark/blob/master/firmware/voodoospark.cpp).
+The first thing you need after this is grab [the latest version of the firmware](https://github.com/voodootikigod/voodoospark/blob/master/firmware/voodoospark.cpp).
 
 Save that file locally, and navigate to the directory in the command line.
 
-Next thing you need to do is flash the firmware, if you are connected to your photon you should be ready. Type the following.
+Next thing you need to do is flash the firmware, if you are connected to your Photon you should be ready. Type the following:
 
 ```
 particle cloud flash PARTICLE_DEVICE_ID voodoospark.cpp
@@ -110,13 +114,13 @@ npm install
 This will pull down all of the dependencies you need.
 
 To configure the Photon Device ID & Token, you can either set it when you start the feeder with the following.
-```$PARTICLE_KEY=your_particle_key $PHOTON_ID=your_photon_id npm start```
+```PARTICLE_KEY=your_particle_key PHOTON_ID=your_photon_id npm start```
 
 Or you can follow through with the rest of this section.
 
-The next step is to update the config.js file with your Photon's Token and Device ID. The Device ID is the same one that you had used in the previous firmware step. Add that in the deviceId object on the line for device, make the device string no longer empty.
+The next step is to update the `config.js` file with your Photon's Token and Device ID. The Device ID is the same one that you had used in the previous firmware step. Add that in the deviceId object on the line for device, make the device string no longer empty.
 
- To get the access token, navigate to the [Particle Build Site](https://build.particle.io/).
+To get the access token, navigate to the [Particle Build Site](https://build.particle.io/).
 
 Click on the settings link on the left, and copy the access token and add it to the appropriate line in your config.js file. It will be the in the token object that asks for device with an empty string. Add it in so the string is no longer empty.
 
@@ -124,17 +128,17 @@ Before we can actually run the code, we need to set up the hardware part.
 
 ### Hardware & Wiring Info
 
-Take the photon which is probably still attached to your computer, you need to attach it to an external power supply.
+Detach the Photon from your computer if it's still attached. We'll connect it to an external power supply now.
 
-All you need is to plug the photon cord into an A/C plug with a usb port, the same kind that you plug your iphone into to charge.
+All you need is to plug the Photon cord into an A/C plug with a UDB port, the same kind that you plug your iPhone into to charge.
 
-Next wire up your photon according to this diagram.
+Next wire up your Photon according to this diagram.
 
 ![Robokitty Wiring Diagram](robokitty_wiring.png)
 
-The 4xAA battery pack wires need to be soldered to two of the MtoM wires that plug into the left rails of the breadboard. Cut off an end of each of the wires and solder the battery pack onto it. 
+The 4xAA battery pack wires need to be soldered to two of the MtoM wires that plug into the left rails of the breadboard. Cut off an end of each of the wires and solder the battery pack onto it.
 
-Now, you need to connect your servo to the dispenser handle. Do this the best way you see fit. It will work even with duct tape, or you can glue your servo horn to the handle (making sure you keep them parallel to each other so it doesn't break). Experiment with it so you find the best way that you see fit. I built a chassis for the servo out of cardboard and duct tape to support the servo while it's turning. You'll have to do the same. Do whatever you want! Acrylic, cardboard, or something else I haven't thought of. I also added a chute to the bottom of the feeder dispenser area that I used a cut up plastic bottle for, because the distance between the mouth of the dispenser and the base was too close, it goes out further in front and allows the cats to access it a lot easier.
+Now, you need to connect your servo to the dispenser handle. Do this the best way you see fit. Even duct tape will work, or you can glue your servo horn to the handle (making sure you keep them parallel to each other so it doesn't break). Experiment with it to find the best way. I built a chassis for the servo out of cardboard and duct tape to support the servo while it's turning. You don't have to do the same. Do whatever you'd like! Acrylic, cardboard, or something else I haven't thought of. I also added a chute to the bottom of the feeder dispenser area that I used a cut up plastic bottle for, because the distance between the mouth of the dispenser and the base was too close. Moving it out further in front allows the cats to access it a lot easier.
 
 Once you're all wired up, you're ready to run the code.
 
@@ -153,10 +157,10 @@ A browser window should now open up at [http://localhost:3000](http://localhost:
 
 You have two options, a button and a dropdown. 
 
-The button is for instantaneous feeding, while the dropdown is for interval feeding. For the alpha release the dropdown is only going to work for that specific session while the page is open. I have added some feature requests to implement a better way of storing the session variables so even if you lose connection with your photon, it will remember. 
+The button is for instantaneous feeding, while the dropdown is for interval feeding. For the alpha release the dropdown is only going to work while the browser is open to that page. I have added some feature requests to implement a better way of storing the session variables so even if you lose connection with your Photon, it will remember. 
 
 Push the button! 
 
-The servo *should* turn and stop after 5 seconds. If it doesn't stop, you may need to tune your servo. If it has a trim pot, you can just turn until it stops. If it doesn't, you may need to open up the bottom of the servo and turn the little knob until it stops. If you can't figure it out, please feel free to [leave a comment here](https://github.com/rachelnicole/robokitty/issues/25) I will try and help you out as best as I can. I'm probably just as new to hardware as you are. :)
+The servo *should* turn and stop after 5 seconds. If it doesn't stop, you may need to tune your servo. If it has a trim pot, you can just turn until it stops. If it doesn't, you may need to open up the bottom of the servo and turn the little knob until it stops. If you can't figure it out, please feel free to [leave a comment here](https://github.com/rachelnicole/robokitty/issues/25) and I'll try and help you out as best as I can. I'm probably just as new to hardware as you are. :)
 
 ![Robokitty gif](robokitty-in-action.gif)


### PR DESCRIPTION
hey @rachelnicole! super quick pass before bed--can look more in-depth tomorrow.

the specific reason not to use links with the link text of 'here' is that they're not great for people using screen readers.

also, i believe in both bash and zsh setting env variables before a command shouldn't use the $ prefix so i changed that as well. :)
